### PR TITLE
feat: auto-start single-file convert queue with generation guard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,12 @@ export default function App() {
   const [state, dispatch] = useReducer(appReducer, initialState);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
+  // Keep a ref to the latest state so async conversions can validate generation.
+  const stateRef = useRef(state);
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+
   // Local lock to avoid starting multiple conversions due to effect re-runs
   // (e.g. React StrictMode, rapid re-renders).
   const inFlightRef = useRef<string | null>(null);
@@ -95,18 +101,26 @@ export default function App() {
     [showToast],
   );
 
+  // Automatic conversion queue (single concurrency).
+  // When there is no active processing item, automatically start the next queued item.
   useEffect(() => {
+    const latest = stateRef.current;
+
     if (inFlightRef.current !== null) {
       return;
     }
-    if (state.activeItemId !== null) {
+    if (latest.activeItemId !== null) {
       return;
     }
 
-    const next = state.items.find((it) => it.status === 'queued');
+    const next = latest.items.find((it) => it.status === 'queued');
     if (!next) {
       return;
     }
+
+    const startedRunId = latest.runId;
+    const startedSettingsRev = latest.settingsRev;
+    const startedQuality = latest.settings.jpegQuality;
 
     inFlightRef.current = next.id;
     dispatch({ type: 'START_ITEM', id: next.id });
@@ -115,18 +129,47 @@ export default function App() {
       try {
         const converted = await ImageFileService.convertToJpeg(
           next.src.imageFile,
-          state.settings.jpegQuality,
+          startedQuality,
         );
 
         const outFile = converted.asFile();
-        const previewUrl = URL.createObjectURL(outFile);
-
         const sizeBefore = next.src.file.size;
         const sizeAfter = outFile.size;
         const reductionRatio =
           sizeBefore > 0
             ? Math.max(0, (sizeBefore - sizeAfter) / sizeBefore)
             : 0;
+
+        // Generation guard: only commit if the run/settings generation is still current.
+        const now1 = stateRef.current;
+        const isCurrentGen1 =
+          now1.runId === startedRunId &&
+          now1.settingsRev === startedSettingsRev;
+
+        if (!isCurrentGen1) {
+          // If the item still exists, put it back to the queue so it can be processed
+          // with the latest settings.
+          if (now1.items.some((it) => it.id === next.id)) {
+            dispatch({ type: 'REQUEUE_ITEM', id: next.id });
+          }
+          return;
+        }
+
+        // Create ObjectURL only after we know it is likely to be accepted.
+        const previewUrl = URL.createObjectURL(outFile);
+
+        // Re-check generation just before dispatch, to avoid races.
+        const now2 = stateRef.current;
+        const isCurrentGen2 =
+          now2.runId === startedRunId &&
+          now2.settingsRev === startedSettingsRev;
+        if (!isCurrentGen2) {
+          safeRevokeObjectURL(previewUrl);
+          if (now2.items.some((it) => it.id === next.id)) {
+            dispatch({ type: 'REQUEUE_ITEM', id: next.id });
+          }
+          return;
+        }
 
         dispatch({
           type: 'FINISH_ITEM',
@@ -141,6 +184,17 @@ export default function App() {
         });
       } catch (e) {
         const msg = e instanceof Error ? e.message : 'Unknown error';
+
+        const now = stateRef.current;
+        const isCurrentGen =
+          now.runId === startedRunId && now.settingsRev === startedSettingsRev;
+        if (!isCurrentGen) {
+          if (now.items.some((it) => it.id === next.id)) {
+            dispatch({ type: 'REQUEUE_ITEM', id: next.id });
+          }
+          return;
+        }
+
         dispatch({ type: 'FAIL_ITEM', id: next.id, error: msg });
       } finally {
         inFlightRef.current = null;
@@ -148,7 +202,7 @@ export default function App() {
     };
 
     run();
-  }, [state.items, state.activeItemId, state.settings.jpegQuality]);
+  }, [state.items, state.activeItemId, state.runId, state.settingsRev]);
 
   const gridItems = selectGridItems(state.items);
   const scrollToId = state.lastAddedIds[state.lastAddedIds.length - 1];


### PR DESCRIPTION
# Summary
- Replaced the manual “Convert” loop with an auto-start queue (single concurrency).
- Automatically starts the next `queued` item when no item is `processing`.
- Added generation guards (`runId` / `settingsRev`) so stale conversion results are discarded.
- Removed the Convert button; the flow is now “add files → auto convert”.
# Details
- The worker effect dispatches `START_ITEM` → runs conversion → `FINISH_ITEM`/`FAIL_ITEM`.
- If `runId` or `settingsRev` changes during an in-flight conversion, the result is ignored and the item is re-queued to avoid blocking the queue.
- ObjectURL creation is guarded by generation checks to prevent leaks on stale results.
# Testing
- Added multiple files while a conversion was running → queue continued automatically.
- Reset / settings changes during conversion → no stale results were committed; queue did not get stuck.