### PR TITLE
feat: Set up issue templates, workflow, and contribution docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,92 @@
+name: Bug report
+description: Something is broken or behaving unexpectedly
+title: '[Bug] '
+labels: ['type:bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please include as much detail as you reasonably can.
+        If you are unsure, submit anyway — it will be triaged.
+
+        **Status is tracked on the Project board** (Inbox/Ready/In Progress/In Review/Blocked/Done).
+
+  - type: textarea
+    id: what_happened
+    attributes:
+      label: What happened?
+      description: Describe the problem.
+      placeholder: 'e.g., Exported images lose capture time when preset "Return to Photos" is enabled.'
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps. Attach sample files if possible.
+      placeholder: |
+        1) ...
+        2) ...
+        3) ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser / OS / device, and anything relevant.
+      placeholder: |
+        - Device:
+        - OS:
+        - Browser:
+    validations:
+      required: false
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      options:
+        - ui
+        - logic
+        - tests
+        - docs
+        - devx
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - high
+        - medium
+        - low
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots (optional)
+      description: Paste logs or screenshots if available. Remove sensitive information.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: docs_impact
+    attributes:
+      label: Docs impact
+      options:
+        - label: 'No doc updates needed'
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question / discussion
+    url: https://github.com/i5irin/gyupic/discussions
+    about: Please ask and discuss here.

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,118 @@
+name: Task
+description: Planned work item (feature, refactor, docs, chore)
+title: '[Task] '
+labels: ['type:task']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to contribute!
+
+        **Please note**
+        - Issues are the source of truth.
+        - The Project board is used for status (Inbox/Ready/In Progress/In Review/Blocked/Done).
+        - If you are unsure about labels, submit the issue anyway; it will be triaged.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What are we trying to achieve?
+      placeholder: 'e.g., Ensure metadata migration preserves XMP best-effort without warnings.'
+    validations:
+      required: true
+
+  - type: textarea
+    id: background
+    attributes:
+      label: Background / context
+      description: Why is this needed? Link related issues/PRs/docs if available.
+      placeholder: "- Related: #123\n- Docs: docs/requirements.md"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which area does this touch most?
+      options:
+        - ui
+        - logic
+        - tests
+        - docs
+        - devx
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How urgent/important is this?
+      options:
+        - high
+        - medium
+        - low
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope / non-goals
+      description: What is in scope? What is explicitly out of scope?
+      placeholder: |
+        **Scope**
+        - ...
+
+        **Non-goals**
+        - ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Checklist of what must be true to close this issue.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: manual_test
+    attributes:
+      label: Manual test scenario (Phase 3/4)
+      description: Provide a short scenario + expected result. If not applicable, write "N/A".
+      placeholder: |
+        Steps:
+        1) ...
+        2) ...
+
+        Expected:
+        - ...
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: docs_impact
+    attributes:
+      label: Docs impact
+      description: Check docs that may need updates.
+      options:
+        - label: 'Update docs/WORKFLOW.md'
+          required: false
+        - label: 'No doc updates needed'
+          required: false
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Implementation notes (optional)
+      description: Suggested approach, pitfalls, or references. Keep non-binding.
+      placeholder: '- Consider state transitions and edge cases...'
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Summary
+
+-
+
+## Related issues
+
+- Closes #
+
+## Changes
+
+-
+-
+
+## How to test
+
+- [ ] Docs-only change
+- Steps:
+  1.
+  2.
+- Expected result:
+
+## Checklist
+
+- [ ] Linked the related issue
+- [ ] Acceptance criteria are met (or updated in the issue)
+- [ ] Manual test scenario is covered
+- [ ] No unnecessary scope creep
+
+## Notes
+
+-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing to gyupic
+
+Thanks for your interest in contributing!
+
+## Where to start
+
+- Please use GitHub Issues for all work items.
+- Issues are the **source of truth** for background, acceptance criteria, and manual test scenarios.
+- GitHub Projects are used for **status tracking only**.
+
+If you are not sure whether something is a bug or a task, create an issue first.
+
+## Creating an Issue
+
+Use the provided issue templates:
+
+- **Task**: feature work, refactors, docs updates, chores
+- **Bug**: user-facing or developer-facing defects
+
+When you file an issue, please include:
+
+- A clear summary (what and why)
+- Acceptance criteria (what must be true to consider it done)
+- Manual test scenario (how to verify)
+
+## Workflow and statuses
+
+We use a simple status flow in GitHub Projects:
+
+- Inbox → Ready → In Progress → In Review → Done
+- Blocked is used when work cannot proceed due to an external dependency
+
+For details, see: `docs/WORKFLOW.md`.
+
+## Working on changes
+
+1. Create a branch from the default branch.
+2. Keep changes small and focused (prefer one PR per issue).
+3. Open a pull request and link the related issue.
+
+## Pull requests
+
+Please include in your PR description:
+
+- What changed (high-level)
+- How to test (manual steps are OK)
+- Any limitations or follow-ups
+
+A PR template is available and will be auto-filled when you open a PR.
+
+## Code style / tests
+
+Follow the existing repository conventions.
+If there are automated checks, please make sure they pass before requesting review.
+
+## Communication
+
+- Use GitHub Issues / PR comments for project discussion.
+- For security issues, see `SECURITY.md`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you believe you have found a security vulnerability, please **do not** open a public GitHub Issue.
+
+Instead, please report it privately using GitHub Security Advisories (preferred):
+
+- Go to the repository page → **Security** → **Advisories** → **New draft security advisory**
+
+If that option is not available, open a minimal issue that contains **no exploit details** and ask the maintainers for a private reporting channel.
+
+## What to include
+
+Please include as much of the following as possible:
+
+- A clear description of the issue and its impact
+- Steps to reproduce (or a proof of concept, if available)
+- Affected versions / commit hashes (if known)
+- Any suggested mitigations or fixes
+
+## Disclosure
+
+We aim to handle reports responsibly and coordinate disclosure when a fix is available.
+Thank you for helping keep the project safe.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -3,6 +3,9 @@
 This document describes how work is tracked and delivered in this repository.
 It is intentionally tooling-agnostic and should work for any contributor environment.
 
+> Start here: If you are new to contributing, please read **CONTRIBUTING.md** first.
+> This document is the detailed workflow reference used by maintainers and reviewers.
+
 ## Source of truth
 
 - **Issues are the source of truth** for scope, acceptance criteria, and test notes.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -1,0 +1,118 @@
+# Workflow
+
+This document describes how work is tracked and delivered in this repository.
+It is intentionally tooling-agnostic and should work for any contributor environment.
+
+## Source of truth
+
+- **Issues are the source of truth** for scope, acceptance criteria, and test notes.
+- The **Project board is a convenience view** for status and filtering.
+
+## Where to ask questions
+
+- Use **Discussions** for questions, ideas, and general support.
+- Use **Issues** for actionable work items (Tasks and Bugs).
+
+## Issue types and templates
+
+Open a new issue using one of these templates:
+
+- **Task**: planned work (feature, refactor, docs, chore).
+- **Bug report**: something is broken or unexpected.
+
+### Required content
+
+Every issue should include:
+
+- Summary
+- Acceptance criteria
+- Manual test scenario (Phase 3/4) or `N/A`
+
+## Labels
+
+This repo uses minimal labels:
+
+- `type:task`
+- `type:bug`
+
+Component and priority are captured in the issue template fields.
+If maintainers decide to add more labels later (e.g., `component:*`, `priority:*`), they should remain prefix-based and be kept minimal.
+
+> Tip: remove unused default GitHub labels to avoid confusion.
+
+## Milestones (phases)
+
+Phases are tracked with **GitHub milestones** (e.g., `Phase 3`, `Phase 4`, `Phase 5`).
+
+- Phase 3/4: manual, scenario-based testing.
+- Phase 5: detailed tests (including test code) become the primary quality gate.
+
+## Project status
+
+The Project board tracks work state. Recommended status values:
+
+- **Inbox**: newly created issue, needs triage
+- **Ready**: scoped and ready to be picked up
+- **In Progress**: actively being worked on
+- **In Review**: implementation done, awaiting review
+- **Blocked**: cannot proceed
+- **Done**: finished (issue closed)
+
+## Testing responsibility (Phase 3/4)
+
+Manual testing is scenario-based in Phase 3/4:
+
+- **In Progress**: the developer runs manual checks following the issue’s “Manual test scenario”.
+- **In Review**: the reviewer re-checks key flows (also following the same scenario),
+  focusing on regressions and edge cases.
+
+If the scenario is insufficient, update the issue to improve it.
+
+## Typical lifecycle
+
+1. **Create an Issue**
+
+   - Use the Task or Bug template.
+   - Assign a milestone (Phase 3/4/5) if known.
+
+2. **Triage (Inbox)**
+
+   - Ensure scope and acceptance criteria are clear.
+   - If actionable: Status **Inbox** → **Ready**.
+   - If it cannot proceed: Status → **Blocked** (add a comment explaining why).
+
+3. **Implement**
+
+   - Create a branch and open a Pull Request (PR).
+   - Link the PR to the issue (e.g., “Closes #123”).
+   - Keep changes focused; split large work into smaller issues if needed.
+
+4. **Review (In Review)**
+
+   - Reviewer checks acceptance criteria and docs impact.
+   - Reviewer performs manual verification per the issue scenario (Phase 3/4).
+   - Address feedback, then merge.
+
+5. **Close**
+   - Close the issue when acceptance criteria are met and verification is complete.
+   - Project Status becomes **Done**.
+
+## Recording decisions (lightweight)
+
+When a design/behavior decision is made, record it in the relevant issue thread as a short comment:
+
+- **Decision**: ...
+- **Rationale**: ...
+- **Impact**: ...
+- **Follow-ups**: ...
+
+This keeps decision history close to the work without introducing a separate process.
+
+## Automation
+
+Project automations should keep manual work low:
+
+- When an issue is created, add it to the Project and set Status to **Inbox**.
+- When an issue is closed, set Status to **Done**.
+
+Avoid relying on Project-only fields for essential information.


### PR DESCRIPTION
## Summary
Set up the repository workflow essentials for contributors and maintainers.

## Changes
- Add GitHub Issue templates (task/bug) and template config
- Document the public workflow (source of truth, statuses, triage/review)
- Add CONTRIBUTING.md and SECURITY.md
- Add a pull request template

## Notes
- No runtime or behavior changes.