### PR TITLE
fix: Normalize job warnings and update ItemsGrid warning UI

### DIFF
--- a/src/components/ItemsGrid.module.css
+++ b/src/components/ItemsGrid.module.css
@@ -89,13 +89,47 @@
   white-space: nowrap;
 }
 
-.warning {
+.warning-wrap {
+  position: relative;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
   margin-top: 6px;
-  overflow: hidden;
+}
+
+.warning-badge {
+  padding: 4px 8px;
   font-size: 12px;
+  line-height: 1;
   color: #92400e;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  cursor: pointer;
+  background: #fffbeb;
+  border: 1px solid #fcd34d;
+  border-radius: 999px;
+}
+
+.warning-list {
+  display: none;
+  padding: 8px 10px;
+  margin-top: 6px;
+  background: #fff7ed;
+  border: 1px solid #fed7aa;
+  border-radius: 10px;
+}
+
+.warning-item {
+  font-size: 12px;
+  line-height: 1.4;
+  color: #9a3412;
+}
+
+.warning-item + .warning-item {
+  margin-top: 6px;
+}
+
+.warning-wrap:hover .warning-list,
+.warning-wrap[data-open='true'] .warning-list {
+  display: block;
 }
 
 .actions {

--- a/src/components/ItemsGrid.tsx
+++ b/src/components/ItemsGrid.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import styles from './ItemsGrid.module.css';
 import type { GridItem } from '../state/selectors';
 
@@ -67,6 +67,7 @@ export default function ItemsGrid({
   queueSummary,
 }: Props) {
   const targetElRef = useRef<HTMLDivElement | null>(null);
+  const [openWarningId, setOpenWarningId] = useState<string | null>(null);
 
   useEffect(() => {
     if (!scrollToId) {
@@ -147,9 +148,38 @@ export default function ItemsGrid({
                   {it.error.message}
                 </div>
               )}
-              {it.status === 'warning' && it.warningReason && (
-                <div className={styles.warning} title={it.warningReason}>
-                  {it.warningReason}
+              {it.status === 'warning' && it.warnings.length > 0 && (
+                <div
+                  className={styles.warningWrap}
+                  data-open={openWarningId === it.id}
+                >
+                  <button
+                    type="button"
+                    className={styles.warningBadge}
+                    aria-expanded={openWarningId === it.id}
+                    aria-controls={`warning-list-${it.id}`}
+                    onClick={() =>
+                      setOpenWarningId((prev) =>
+                        prev === it.id ? null : it.id,
+                      )
+                    }
+                  >
+                    Warnings {it.warnings.length}
+                  </button>
+                  <div
+                    id={`warning-list-${it.id}`}
+                    className={styles.warningList}
+                    role="status"
+                  >
+                    {it.warnings.map((warning, index) => (
+                      <div
+                        key={`${it.id}-warning-${warning.code}-${index}`}
+                        className={styles.warningItem}
+                      >
+                        {warning.message}
+                      </div>
+                    ))}
+                  </div>
                 </div>
               )}
 

--- a/src/core/execution/queueManager.ts
+++ b/src/core/execution/queueManager.ts
@@ -151,13 +151,7 @@ export default class QueueManager {
       return;
     }
 
-    const { file: normalizedFile, warning: cloneWarning } =
-      this.reconcileOutputFile(result);
-    const combinedWarning = this.combineWarnings(
-      result.warningReason,
-      result.filenameWarning,
-      cloneWarning,
-    );
+    const { file: normalizedFile } = this.reconcileOutputFile(result);
     const previewUrl = this.createObjectURL(normalizedFile);
 
     if (this.isCanceled(itemId)) {
@@ -182,7 +176,7 @@ export default class QueueManager {
         reductionRatio: result.reductionRatio,
         metadata: result.metadata,
       },
-      warningReason: combinedWarning,
+      warnings: result.warnings,
     });
     this.canceledIds.delete(itemId);
   }
@@ -214,7 +208,6 @@ export default class QueueManager {
   // eslint-disable-next-line class-methods-use-this
   private reconcileOutputFile(result: ProcessingPipelineResult): {
     file: File;
-    warning?: string;
   } {
     if (
       !result.expectedFileName ||
@@ -226,23 +219,7 @@ export default class QueueManager {
       type: result.file.type,
       lastModified: result.file.lastModified,
     });
-    return {
-      file: repaired,
-      warning: 'File name restored after worker transfer.',
-    };
-  }
-
-  // eslint-disable-next-line class-methods-use-this
-  private combineWarnings(
-    ...messages: Array<string | undefined>
-  ): string | undefined {
-    const filtered = messages.filter(
-      (msg): msg is string => typeof msg === 'string' && msg.length > 0,
-    );
-    if (filtered.length === 0) {
-      return undefined;
-    }
-    return filtered.join(' / ');
+    return { file: repaired };
   }
 
   private isCanceled(itemId: string): boolean {

--- a/src/core/metadata/metadataCoreAdapter.ts
+++ b/src/core/metadata/metadataCoreAdapter.ts
@@ -55,7 +55,6 @@ export type MetadataCoreDeriveSession = {
 export type MetadataCoreApplyResult = {
   file: File;
   status: MetadataGuaranteeStatus;
-  warningReason?: string;
   warnings: MetadataWarning[];
   captureTimeBadge?: string;
 };
@@ -87,11 +86,12 @@ function mapLegacyApplyResult(
     reason: legacyReason,
     message: buildMetadataWarningMessage(legacyField, legacyReason),
   };
+  const shouldWarn =
+    result.status === 'warning' || result.status === 'best-effort';
   return {
     file: result.file,
     status: result.status,
-    warningReason: result.warningReason ? legacyWarning.message : undefined,
-    warnings: result.warningReason ? [legacyWarning] : [],
+    warnings: shouldWarn ? [legacyWarning] : [],
     captureTimeBadge: deriveLegacyBadge(result, requirements),
   };
 }
@@ -240,24 +240,15 @@ function buildFileFromWasmResponse(
 function evaluateGuaranteeStatus(options: {
   requirements: MetadataRequirements;
   captureApplied: boolean;
-  warnings: MetadataWarning[];
-}): {
-  status: MetadataGuaranteeStatus;
-  warningReason?: string;
-} {
-  const { requirements, captureApplied, warnings } = options;
+}): MetadataGuaranteeStatus {
+  const { requirements, captureApplied } = options;
   if (!requirements.captureTime.enabled) {
-    return { status: 'skipped' };
+    return 'skipped';
   }
   if (captureApplied) {
-    return { status: 'guaranteed' };
+    return 'guaranteed';
   }
-  return {
-    status: 'warning',
-    warningReason:
-      warnings[0]?.message ||
-      'Capture time could not be applied to the output image.',
-  };
+  return 'warning';
 }
 
 async function tryApplyWithWasm(
@@ -271,10 +262,9 @@ async function tryApplyWithWasm(
     const file = buildFileFromWasmResponse(response.output, options, response);
     return {
       file,
-      ...evaluateGuaranteeStatus({
+      status: evaluateGuaranteeStatus({
         requirements: options.requirements,
         captureApplied: response.appliedFlags.captureTime,
-        warnings: response.warnings,
       }),
       warnings: response.warnings,
       captureTimeBadge: response.captureTimeBadge,

--- a/src/core/metadata/metadataPolicy.ts
+++ b/src/core/metadata/metadataPolicy.ts
@@ -223,7 +223,6 @@ type ApplyOptions = {
 export type ApplyResult = {
   file: File;
   status: MetadataGuaranteeStatus;
-  warningReason?: string;
 };
 
 type ExifTimestampField = (typeof EXIF_TIMESTAMP_FIELDS)[number];
@@ -341,27 +340,16 @@ function evaluateStatus(options: {
   success: boolean;
   requirements: MetadataRequirements;
   fallbackUsed?: boolean;
-  failureReason?: string;
-  fallbackReason?: string;
-}): { status: MetadataGuaranteeStatus; warningReason?: string } {
-  const { success, requirements, fallbackUsed, failureReason, fallbackReason } =
-    options;
+}): { status: MetadataGuaranteeStatus } {
+  const { success, requirements, fallbackUsed } = options;
   if (!requirements.captureTime.enabled) {
     return { status: 'skipped' };
   }
   if (!success) {
-    return {
-      status: 'warning',
-      warningReason: failureReason || 'Capture time could not be written.',
-    };
+    return { status: 'warning' };
   }
   if (fallbackUsed) {
-    return {
-      status: 'best-effort',
-      warningReason:
-        fallbackReason ||
-        'Best-effort: used edited/file timestamp because capture time was unavailable.',
-    };
+    return { status: 'best-effort' };
   }
   return { status: 'guaranteed' };
 }
@@ -500,7 +488,6 @@ export async function applyTimestamp({
       ...evaluateStatus({
         success: false,
         requirements,
-        failureReason: 'Timestamp unavailable.',
       }),
     };
   }
@@ -545,7 +532,6 @@ export async function applyTimestamp({
         ...evaluateStatus({
           success: false,
           requirements,
-          failureReason: 'Unsupported timestamp format.',
         }),
       };
     }
@@ -569,7 +555,6 @@ export async function applyTimestamp({
           ...evaluateStatus({
             success: false,
             requirements,
-            failureReason: 'Failed to inject Exif timestamp',
           }),
         };
       }
@@ -593,7 +578,6 @@ export async function applyTimestamp({
           ...evaluateStatus({
             success: false,
             requirements,
-            failureReason: 'Failed to inject Exif timestamp',
           }),
         };
       }
@@ -603,8 +587,6 @@ export async function applyTimestamp({
         ...evaluateStatus({
           success: false,
           requirements,
-          failureReason:
-            'Capture time injection requires the metadata core for WebP output.',
         }),
       };
     } else if (needsExif && !fallbackUsed) {
@@ -613,7 +595,6 @@ export async function applyTimestamp({
         ...evaluateStatus({
           success: false,
           requirements,
-          failureReason: 'File type does not support Exif metadata.',
         }),
       };
     }
@@ -623,7 +604,6 @@ export async function applyTimestamp({
       ...evaluateStatus({
         success: false,
         requirements,
-        failureReason: 'File type does not support Exif metadata.',
       }),
     };
   }
@@ -639,17 +619,12 @@ export async function applyTimestamp({
   }
 
   const success = needsExif ? derivedIsExif || fallbackUsed : true;
-  const fallbackReason = fallbackUsed
-    ? 'Best-effort: timestamp derived from edited/lastModified metadata.'
-    : undefined;
-
   return {
     file: workingFile,
     ...evaluateStatus({
       success,
       requirements,
       fallbackUsed,
-      fallbackReason,
     }),
   };
 }

--- a/src/core/pipeline/processingPipeline.ts
+++ b/src/core/pipeline/processingPipeline.ts
@@ -10,7 +10,11 @@ import {
   buildMetadataRequirements,
   shouldDeriveCaptureTime,
 } from '../../domain/metadataRequirements';
-import type { DerivedTimestamp, JobMetadataInfo } from '../../state/jobTypes';
+import type {
+  DerivedTimestamp,
+  JobMetadataInfo,
+  MetadataWarning,
+} from '../../state/jobTypes';
 import {
   applyMetadataWithMetadataCore,
   deriveTimestampWithMetadataCore,
@@ -18,6 +22,7 @@ import {
   type MetadataCoreDeriveSession,
 } from '../metadata/metadataCoreAdapter';
 import { parseExifDateTime } from '../metadata/metadataPolicy';
+import { buildMetadataWarningMessage } from '../metadata/wasmBridge';
 import {
   canUseOffscreenConversion,
   convertWithOffscreenCanvas,
@@ -41,8 +46,7 @@ export type ProcessingPipelineResult = {
   sizeAfter: number;
   reductionRatio: number;
   metadata: JobMetadataInfo;
-  warningReason?: string;
-  filenameWarning?: string;
+  warnings: MetadataWarning[];
   expectedFileName?: string;
 };
 
@@ -110,7 +114,7 @@ function formatTimestampForFilename(date: Date): string {
 type FilenamePlan = {
   targetName?: string;
   timestampMs?: number;
-  warning?: string;
+  warnings: MetadataWarning[];
 };
 
 function resolveLegacyTimestampMs(options: {
@@ -149,7 +153,7 @@ function buildLegacyFilenamePlan(options: {
     outputFormat,
   } = options;
   if (filenameStrategy === 'keep-original') {
-    return {};
+    return { warnings: [] };
   }
   const timestampMs = resolveLegacyTimestampMs({
     filenameTimestampSource,
@@ -158,7 +162,17 @@ function buildLegacyFilenamePlan(options: {
   });
   if (!timestampMs) {
     return {
-      warning: 'Rename skipped: Timestamp unavailable.',
+      warnings: [
+        {
+          code: 'META_MISSING_INPUT',
+          field: 'OUTPUT_FILENAME',
+          reason: 'missing in input',
+          message: buildMetadataWarningMessage(
+            'OUTPUT_FILENAME',
+            'missing in input',
+          ),
+        },
+      ],
     };
   }
   const date = new Date(timestampMs);
@@ -168,6 +182,7 @@ function buildLegacyFilenamePlan(options: {
   return {
     targetName: `${timestamp}_${baseName}${config.extension}`,
     timestampMs,
+    warnings: [],
   };
 }
 
@@ -188,7 +203,7 @@ async function planOutputFilename(options: {
     session,
   } = options;
   if (filenameStrategy === 'keep-original') {
-    return {};
+    return { warnings: [] };
   }
   if (session.mode === 'wasm') {
     try {
@@ -206,10 +221,7 @@ async function planOutputFilename(options: {
           Number.isFinite(planResult.timestampMs)
             ? planResult.timestampMs
             : undefined,
-        warning:
-          Array.isArray(planResult.warnings) && planResult.warnings.length > 0
-            ? planResult.warnings.map((warning) => warning.message).join(' / ')
-            : undefined,
+        warnings: planResult.warnings ?? [],
       };
     } catch (error) {
       // eslint-disable-next-line no-console
@@ -314,10 +326,10 @@ export async function runProcessingPipeline(
     presetId,
     derived: derivedTimestamp,
     status: applyResult.status,
-    reason: applyResult.warningReason,
+    reason: applyResult.warnings[0]?.message,
     captureTimeBadge: applyResult.captureTimeBadge,
-    warnings: applyResult.warnings.map((warning) => warning.message),
   };
+  const warnings = [...applyResult.warnings, ...filenamePlan.warnings];
 
   return {
     file: finalFile,
@@ -325,8 +337,7 @@ export async function runProcessingPipeline(
     sizeAfter,
     reductionRatio,
     metadata,
-    warningReason: applyResult.warningReason,
-    filenameWarning: filenamePlan.warning,
+    warnings,
     expectedFileName: finalFile.name,
   };
 }

--- a/src/state/appReducer.ts
+++ b/src/state/appReducer.ts
@@ -14,7 +14,7 @@ export type AppAction =
       type: 'FINISH_ITEM';
       id: string;
       out: JobItem['out'];
-      warningReason?: string;
+      warnings: JobItem['warnings'];
     }
   | { type: 'FAIL_ITEM'; id: string; error: JobErrorInfo }
   | { type: 'RETRY_ITEM'; id: string }
@@ -72,7 +72,13 @@ export default function appReducer(
       const ids = action.items.map((it) => it.id);
       return {
         ...state,
-        items: [...state.items, ...action.items],
+        items: [
+          ...state.items,
+          ...action.items.map((item) => ({
+            ...item,
+            warnings: item.warnings ?? [],
+          })),
+        ],
         lastAddedIds: ids,
       };
     }
@@ -92,14 +98,15 @@ export default function appReducer(
           status: 'processing',
           isNew: false,
           error: undefined,
-          warningReason: undefined,
+          warnings: [],
           captured: snapshot,
         })),
       };
     }
 
     case 'FINISH_ITEM': {
-      const status = action.warningReason ? 'warning' : 'done';
+      const warnings = action.warnings ?? [];
+      const status = warnings.length > 0 ? 'warning' : 'done';
       return {
         ...state,
         activeItemIds: state.activeItemIds.filter((id) => id !== action.id),
@@ -108,7 +115,7 @@ export default function appReducer(
           status,
           out: action.out,
           error: undefined,
-          warningReason: action.warningReason,
+          warnings,
         })),
       };
     }
@@ -133,7 +140,7 @@ export default function appReducer(
           status: 'queued',
           out: undefined,
           error: undefined,
-          warningReason: undefined,
+          warnings: [],
           isNew: false,
         })),
       };
@@ -158,7 +165,7 @@ export default function appReducer(
           isNew: false,
           out: undefined,
           error: undefined,
-          warningReason: undefined,
+          warnings: [],
         })),
       };
     }
@@ -175,7 +182,7 @@ export default function appReducer(
           status: 'queued',
           out: undefined,
           error: undefined,
-          warningReason: undefined,
+          warnings: [],
           isNew: false,
         })),
       };

--- a/src/state/jobTypes.ts
+++ b/src/state/jobTypes.ts
@@ -5,6 +5,7 @@ import type {
   PresetId,
   TimestampWriteMode,
 } from '../domain/presets';
+import type { MetadataWarning as CoreMetadataWarning } from '../core/metadata/wasmBridge';
 
 export type JobStatus =
   | 'queued'
@@ -40,13 +41,14 @@ export type MetadataGuaranteeStatus =
   | 'warning'
   | 'skipped';
 
+export type MetadataWarning = CoreMetadataWarning;
+
 export type JobMetadataInfo = {
   presetId: PresetId;
   derived: DerivedTimestamp;
   status: MetadataGuaranteeStatus;
   reason?: string;
   captureTimeBadge?: string;
-  warnings?: string[];
 };
 
 export type JobErrorCode =
@@ -83,7 +85,7 @@ export type JobItem = {
   src: JobSource;
   out?: JobOutput;
   error?: JobErrorInfo;
-  warningReason?: string;
+  warnings?: MetadataWarning[];
   captured?: JobCaptureSnapshot;
 };
 

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -1,4 +1,9 @@
-import type { JobItem, JobStatus, JobErrorInfo } from './jobTypes';
+import type {
+  JobItem,
+  JobStatus,
+  JobErrorInfo,
+  MetadataWarning,
+} from './jobTypes';
 
 export type GridActionState = {
   canRetry: boolean;
@@ -14,7 +19,7 @@ export type GridItem = {
   status: JobStatus;
   isNew: boolean;
   error?: JobErrorInfo;
-  warningReason?: string;
+  warnings: MetadataWarning[];
   actions: GridActionState;
 };
 
@@ -39,7 +44,7 @@ export function selectGridItems(items: JobItem[]): GridItem[] {
       status: it.status,
       isNew: it.isNew,
       error: it.error,
-      warningReason: it.warningReason,
+      warnings: it.warnings ?? [],
       actions,
     };
   });


### PR DESCRIPTION
## Summary

- Normalize warnings into JobItem.warnings and remove warningReason
- Wire warnings through pipeline/worker and update ItemsGrid warning UI

## Related issues

- Closes #17 

## Changes

- Replace warningReason path with normalized warnings arrays
- Add warning count badge and warning list display in ItemsGrid

## How to test

1. Process a file that triggers OUTPUT_FILENAME warning.
2. Hover (desktop) or tap (mobile) the warning badge to view messages.
- Expected result:
  - Warning count is shown, messages appear, and download/share remains enabled.

## Checklist

- [x] Linked the related issue
- [x] Acceptance criteria are met (or updated in the issue)
- [x] Manual test scenario is covered
- [x] No unnecessary scope creep

## Notes

- Warning list is displayed inline to avoid overflow clipping.

